### PR TITLE
SingleSecretKeyRingProtector

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/ConsumerOptions.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/ConsumerOptions.java
@@ -24,6 +24,7 @@ import org.bouncycastle.openpgp.PGPSecretKeyRingCollection;
 import org.bouncycastle.openpgp.PGPSignature;
 import org.pgpainless.exception.NotYetImplementedException;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
+import org.pgpainless.key.protection.SingleSecretKeyRingProtector;
 import org.pgpainless.signature.SignatureUtils;
 import org.pgpainless.util.Passphrase;
 
@@ -195,15 +196,22 @@ public class ConsumerOptions {
     }
 
     /**
-     * Add a key for message decryption. If the key is encrypted, the {@link SecretKeyRingProtector} is used to decrypt it
+     * Add a key ring for message decryption. If the key ring is encrypted, the {@link SecretKeyRingProtector} is used to decrypt it
      * when needed.
      *
-     * @param key key
+     * @param keyRing key ring
      * @param keyRingProtector protector for the secret key
      * @return options
      */
-    public ConsumerOptions addDecryptionKey(@Nonnull PGPSecretKeyRing key, @Nonnull SecretKeyRingProtector keyRingProtector) {
-        decryptionKeys.put(key, keyRingProtector);
+    public ConsumerOptions addDecryptionKey(@Nonnull PGPSecretKeyRing keyRing, @Nonnull SecretKeyRingProtector keyRingProtector) {
+        decryptionKeys.forEach((key, value) -> {
+            if (value instanceof SingleSecretKeyRingProtector && value != keyRingProtector){
+                throw new IllegalStateException("SingleSecretKeyRingProtector is found. " +
+                        "Please specify the same SecretKeyRingProtector for all keys.");
+            }
+        });
+
+        decryptionKeys.put(keyRing, keyRingProtector);
         return this;
     }
 

--- a/pgpainless-core/src/main/java/org/pgpainless/exception/WrongPassphraseException.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/exception/WrongPassphraseException.java
@@ -4,9 +4,15 @@
 
 package org.pgpainless.exception;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.bouncycastle.openpgp.PGPException;
 
 public class WrongPassphraseException extends PGPException {
+    private Map<Long, Exception> keyIds = Collections.emptyMap();
 
     public WrongPassphraseException(String message) {
         super(message);
@@ -14,9 +20,21 @@ public class WrongPassphraseException extends PGPException {
 
     public WrongPassphraseException(long keyId, PGPException cause) {
         this("Wrong passphrase provided for key " + Long.toHexString(keyId), cause);
+        this.keyIds = new HashMap<>();
+        this.keyIds.put(keyId, cause);
+    }
+
+    public WrongPassphraseException(Map<Long, Exception> keyIds) {
+        this("Wrong passphrase provided for keys: " +
+                keyIds.keySet().stream().map(Long::toHexString).collect(Collectors.joining(", ")));
+        this.keyIds = keyIds;
     }
 
     public WrongPassphraseException(String message, PGPException cause) {
         super(message, cause);
+    }
+
+    public Map<Long, Exception> getKeyIds() {
+        return keyIds;
     }
 }

--- a/pgpainless-core/src/main/java/org/pgpainless/key/protection/SingleSecretKeyRingProtector.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/key/protection/SingleSecretKeyRingProtector.java
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2018 Paul Schaub <vanitasvitae@fsfe.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.pgpainless.key.protection;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+/**
+ * This interface assumes that all handled keys will use a single
+ * realization of {@link SecretKeyRingProtector}.
+ */
+public interface SingleSecretKeyRingProtector {
+    Map<Long, Exception> failedKeyIds = new HashMap<>();
+
+    /**
+     * Return a map that contains a key id of each key that was not unlocked.
+     *
+     * @return a map of key ids.
+     */
+    @Nonnull
+    default Map<Long, Exception> getFailedKeyIds() {
+        return failedKeyIds;
+    }
+
+    /**
+     * Add a key id of some key that was not unlocked due to {@code e}
+     *
+     * @param keyId the key id
+     * @param e     an instance of {@link Exception}
+     */
+    default void addFailedKeyId(long keyId, Exception e) {
+        failedKeyIds.put(keyId, e);
+    }
+}


### PR DESCRIPTION
Added `SingleSecretKeyRingProtector` to resolve a situation when we want to know all failed private keys during the decryption process. It relates to #183. 

@vanitasvitae Please look at my changes. I'd like to share an example that resolves our needs. It would be great to know all keys that were not unlocked during decryption. I was trying to don't break compatibility with old code.

The following code demonstrates what we expect

```java
@Test
    public void missingPassphraseFirstAndSecond() throws PGPException, IOException {
        PGPSecretKeyRingCollection keyRings = new PGPSecretKeyRingCollection(Arrays.asList(k1, k2));
        assertThrows(WrongPassphraseException.class, () -> {
            DecryptionStream decryptionStream = PGPainless.decryptAndOrVerify()
                    .onInputStream(new ByteArrayInputStream(ENCRYPTED_FOR_K1_K2.getBytes(StandardCharsets.UTF_8)))
                    .withOptions(new ConsumerOptions()
                            .addDecryptionKeys(keyRings, new SingleCachingSecretKeyRingProtector()));

            ByteArrayOutputStream out = new ByteArrayOutputStream();
            Streams.pipeAll(decryptionStream, out);
            decryptionStream.close();
        }, "Wrong passphrase provided for keys: a7c78cc7690fcc46, 10da90900b1cec68");
    }
```

I've added `SingleSecretKeyRingProtector` which should be the same `SecretKeyRingProtector ` for all protected keys. Only, in that case, it makes sense.

ref https://github.com/FlowCrypt/flowcrypt-android/issues/1473

