### PR TITLE
Fixed typo in sop readme

### DIFF
--- a/pgpainless-sop/README.md
+++ b/pgpainless-sop/README.md
@@ -67,7 +67,7 @@ byte[] encrypted = sop.encrypt()
 
 // Decrypt a message
 ByteArrayAndResult<DecryptionResult> messageAndVerifications = sop.decrypt()
-        .verifyWith(cert)
+        .verifyWithCert(cert)
         .withKey(key)
         .ciphertext(encrypted)
         .toByteArrayAndResult();


### PR DESCRIPTION
Fixed a typo in the README.md for `pgpainless-sop`. The `verifyWith` method doesn't exist while `verifyWithCert` does.