### PR TITLE
Fix wrong RFC number referenced (4480 instead of 4880)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 PGPainless - Painless OpenPGP
 =============================
 
-**OpenPGP** (`RFC 4480 <https://datatracker.ietf.org/doc/rfc4880/>`_) is an Internet Standard mostly used for email
+**OpenPGP** (`RFC 4880 <https://datatracker.ietf.org/doc/rfc4880/>`_) is an Internet Standard mostly used for email
 encryption.
 It provides mechanisms to ensure *confidentiality*, *integrity* and *authenticity* of messages.
 However, OpenPGP can also be used for other purposes, such as secure messaging or as a signature mechanism for

--- a/pgpainless-core/src/main/kotlin/org/pgpainless/policy/Policy.kt
+++ b/pgpainless-core/src/main/kotlin/org/pgpainless/policy/Policy.kt
@@ -377,11 +377,11 @@ class Policy {
                     override fun isAcceptable(
                         encryptionMechanism: MessageEncryptionMechanism
                     ): Boolean {
-                        val rfc4480 = rfc4880(symAlgPolicy)
+                        val rfc4880 = rfc4880(symAlgPolicy)
                         val rfc9580 = rfc9580(symAlgPolicy)
                         val librePgp = librePgp(symAlgPolicy)
 
-                        return rfc4480.isAcceptable(encryptionMechanism) ||
+                        return rfc4880.isAcceptable(encryptionMechanism) ||
                             rfc9580.isAcceptable(encryptionMechanism) ||
                             librePgp.isAcceptable(encryptionMechanism)
                     }


### PR DESCRIPTION
The docs landing page and one part of code reference RFC 4480 - RPID instead of RFC 4880 - OpenPGP. The documentation links correctly to RFC 4880, just the visual text is wrong